### PR TITLE
fix: class error when passing arguments

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -318,7 +318,10 @@ impl Interpreter {
                 callee.check_arity(evaluated_args.len(), paren)?;
                 callee.call(self, evaluated_args)
             }
-            Value::Class(callee) => callee.call(self, vec![]),
+            Value::Class(callee) => {
+                callee.check_arity(evaluated_args.len(), paren)?;
+                callee.call(self, evaluated_args)
+            },
             _ => Exception::runtime_error(
                 paren.clone(),
                 String::from("Can only call functions and classes."),

--- a/test_files/class.lox
+++ b/test_files/class.lox
@@ -1,0 +1,12 @@
+class Player {
+    init(name) {
+        this.name = name;
+    }
+
+    run() {
+        print("Player " + this.name + " is running...");
+    }
+}
+
+var p = Player("Foo");
+p.run();


### PR DESCRIPTION
Hi, Nguyen!  😊

Awesome project! I've been following your code while learning Rust, and it's been incredibly helpful. Thank you for sharing your work—it’s really helping me level up my skills.

I noticed an issue that occurs when arguments are passed to the init method in a class, and I’ve made a small fix to address it. Hope this helps!

```Javascript
class Player {
    // Construtor fails when arguments are passed
    init(name) {
        this.name = name;
    }

    run() {
        print("Player " + this.name + " is running...");
    }
}

//             <here>
var p = Player("Foo");
p.run();
```

Thanks again for the fantastic project!